### PR TITLE
Fix aeson bounds

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -80,7 +80,7 @@ library
         , Network.AWS.Sign.V4.Chunked
 
     build-depends:
-          aeson                >= 0.8
+          aeson                >= 2.0
         , attoparsec           >= 0.11.3
         , base                 >= 4.7 && < 5
         , bifunctors           >= 4.1


### PR DESCRIPTION
Use of `Data.Aeson.Key` implies aeson >= 2.0.
edit: Or is there an aeson package that can make it compile with both 1.5.6.0  and 2.0?
cc @jsynacek 